### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "type": "git",
     "url": "https://github.com/mollie/mollie-api-typescript.git"
   },
+  "license": "BSD-2-Clause",
   "scripts": {
     "lint": "eslint --cache --max-warnings=0 src",
     "build": "tshy",


### PR DESCRIPTION
## Summary
- add BSD-2-Clause license metadata to the npm package manifest
- align package metadata with the repository LICENSE.md and GitHub license detection
- leave runtime code, dependencies, exports, generated SDK files, and lockfiles unchanged

## Verification
- node package manifest assertion
- git diff --check
- npm pack --dry-run --ignore-scripts --json